### PR TITLE
Fix the pre-allocated number of pages

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ function Pager (pageSize) {
 
   this.length = 0
   this.updates = []
-  this.pages = new Array(16 * 1024)
+  this.pages = new Array(16)
   this.pageSize = pageSize || 1024
 }
 


### PR DESCRIPTION
This solves the memory issue described in https://github.com/mafintosh/hypercore/pull/121

I noticed the number of pre-allocated pages seemed off. To confirm, I added some code to hashbase which tracked how frequently pages of a given offset were being allocated. After 15 minutes running in hashbase, this was the count:

```
{ '0': 7657,
  '1': 37,
  '2': 10,
  '3': 10,
  '4': 8,
  '5': 5,
  '6': 3,
  '7': 1,
  '8': 1,
  '9': 1,
  '10': 1,
  '11': 1 }
```

Not even up to 16! So I reduced the number preallocated in Hashbase, as this PR does, and things continued to work smoothly -- and then my CPU usage dropped completely. The hashbase loop delay used to *start* at 200ms and grow from there till I had to restart. Now it sits comfortably at 0.5ms to 2ms. Victory!